### PR TITLE
Send the :authority pseudo-header on requests

### DIFF
--- a/src/grpc.act
+++ b/src/grpc.act
@@ -133,6 +133,7 @@ actor Channel(cap: net.TCPConnectCap, target: str, options: list[ChannelArgument
 
         headers = { ':method': 'POST',
                     ':scheme': scheme,
+                    ':authority': host + ":" + str(port),
                     ':path': path,
                     'te': 'trailers',
                     'content-type': 'application/grpc' }
@@ -184,6 +185,7 @@ actor Channel(cap: net.TCPConnectCap, target: str, options: list[ChannelArgument
 
         headers = { ':method': 'POST',
                     ':scheme': scheme,
+                    ':authority': host + ":" + str(port),
                     ':path': path,
                     'te': 'trailers',
                     'content-type': 'application/grpc' }


### PR DESCRIPTION
HTTP/2 makes the :authority pseudo-header mandatory on requests, and strict servers reject a request that lacks it. Connecting an Acton gNMI client to Nokia SR Linux, its Go gRPC server refused every call until :authority was sent.

This sets :authority from the channel's target host and port on both the unary and the streaming request header sets, alongside the existing :method, :scheme and :path. With acton-http2 now ordering pseudo-headers ahead of regular headers the placement within the dict no longer matters, but the header still has to be present.