### PR TITLE
Log response headers at debug instead of printing them

### DIFF
--- a/src/grpc.act
+++ b/src/grpc.act
@@ -118,7 +118,7 @@ actor Channel(cap: net.TCPConnectCap, target: str, options: list[ChannelArgument
     def unary_unary(path: str, message: bytes, on_response: action(Channel, bytes) -> None, additional_headers: dict[str, str] = {}):
         
         def _on_headers_recv(c: http2.client.Http2Client, stream_id: u32, headers: dict[str, str], end_stream: bool):
-            print(headers)
+            logger.debug('Received response headers', {'stream_id': stream_id, 'headers': headers})
 
         def _on_data_recv(c: http2.client.Http2Client, stream_id: u32, data: bytes, end_stream: bool):
             logger.debug('Received message data', {'data': data, 'stream_id': stream_id})
@@ -157,7 +157,7 @@ actor Channel(cap: net.TCPConnectCap, target: str, options: list[ChannelArgument
 
     def stream_stream(path: str, messages: list[bytes], on_response: action(Channel, bytes) -> None, additional_headers: dict[str, str] = {}) -> MessageQueue:
         def _on_headers_recv(c: http2.client.Http2Client, stream_id: u32, headers: dict[str, str], end_stream: bool):
-            print(headers)
+            logger.debug('Received response headers', {'stream_id': stream_id, 'headers': headers})
 
         def _on_data_recv(c: http2.client.Http2Client, stream_id: u32, data: bytes, end_stream: bool):
             logger.debug('Received message data', {'data': data, 'stream_id': stream_id})


### PR DESCRIPTION
Both the unary and streaming response paths printed the received header dict to stdout from the on-headers callback, so every gRPC call dumped a line like {':status':'200', ...}. Route it through the channel's debug logger instead, matching the rest of the module, so it stays available under verbose logging but is quiet by default.